### PR TITLE
docs: fix documentation site URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,12 @@ zod-codepen/
 
 ## Documentation
 
-Visit the [documentation site](https://zod-codepen.dev) for detailed guides and API reference.
+Visit the [documentation site](https://zod-codepen.corn.im) for detailed guides and API reference.
 
-- [Getting Started](https://zod-codepen.dev/guide/getting-started)
-- [API Reference](https://zod-codepen.dev/api/)
-- [v3/v4 Migration Guide](https://zod-codepen.dev/guide/migration)
-- [Custom Handlers](https://zod-codepen.dev/guide/custom-handlers)
+- [Getting Started](https://zod-codepen.corn.im/guide/getting-started)
+- [API Reference](https://zod-codepen.corn.im/api/)
+- [v3/v4 Migration Guide](https://zod-codepen.corn.im/guide/migration)
+- [Custom Handlers](https://zod-codepen.corn.im/guide/custom-handlers)
 
 ## Development
 


### PR DESCRIPTION
## Summary
- The English `README.md` pointed the documentation site links to `zod-codepen.dev`, which fails to resolve (TLS handshake failure) — this is the root cause of #5.
- Replaced all 5 references (lines 214–219) with the working domain `zod-codepen.corn.im`, matching the existing banner link (line 11) and `README.zh_CN.md`.
- No code changes; doc-only fix.

## Verification
```
$ curl -sI https://zod-codepen.corn.im
HTTP/2 200

$ curl -sI https://zod-codepen.dev
curl: (35) TLS handshake failure
```

## Test plan
- [x] Click each updated link in `README.md` and confirm it resolves to the correct page on the live docs site.
- [x] Confirm `README.zh_CN.md` was already correct (no changes needed there).

Fixes #5